### PR TITLE
Match current favicon standards

### DIFF
--- a/Controllers/DefaultController.cs
+++ b/Controllers/DefaultController.cs
@@ -33,7 +33,37 @@ namespace Etch.OrchardCore.Favicon.Controllers
         #region Actions
 
         [HttpGet]
-        [Route("icon.png")]
+        [Route("android-chrome-192x192.png")]
+        public async Task<IActionResult> AndroidSmallIcon()
+        {
+            var settings = await GetSettings();
+
+            if (settings == null || !settings.HasAndroidSmallIcon)
+            {
+                return NotFound();
+            }
+
+            _contentTypeProvider.TryGetContentType(settings.AndroidSmallIconPath, out var contentType);
+            return File(await _mediaFileStore.GetFileStreamAsync(settings.AndroidSmallIconPath), contentType ?? DefaultMimeTypes.PngIcon);
+        }
+
+        [HttpGet]
+        [Route("android-chrome-512x512.png")]
+        public async Task<IActionResult> AndroidLargeIcon()
+        {
+            var settings = await GetSettings();
+
+            if (settings == null || !settings.HasAndroidLargeIcon)
+            {
+                return NotFound();
+            }
+
+            _contentTypeProvider.TryGetContentType(settings.AndroidLargeIconPath, out var contentType);
+            return File(await _mediaFileStore.GetFileStreamAsync(settings.AndroidLargeIconPath), contentType ?? DefaultMimeTypes.PngIcon);
+        }
+
+        [HttpGet]
+        [Route("apple-touch-icon.png")]
         public async Task<IActionResult> AppleTouchIcon()
         {
             var settings = await GetSettings();
@@ -44,7 +74,7 @@ namespace Etch.OrchardCore.Favicon.Controllers
             }
 
             _contentTypeProvider.TryGetContentType(settings.AppleTouchIconPath, out var contentType);
-            return File(await _mediaFileStore.GetFileStreamAsync(settings.FaviconPath), contentType ?? DefaultMimeTypes.AppleTouchIcon);
+            return File(await _mediaFileStore.GetFileStreamAsync(settings.AppleTouchIconPath), contentType ?? DefaultMimeTypes.PngIcon);
         }
 
         [HttpGet]
@@ -53,7 +83,7 @@ namespace Etch.OrchardCore.Favicon.Controllers
         {
             var settings = await GetSettings();
 
-            if (settings == null || (!settings.HasBrowserConfig && !(settings.HasTile || settings.HasTileWide)))
+            if (settings == null || (!settings.HasBrowserConfig && !settings.HasTile))
             {
                 return NotFound();
             }
@@ -73,13 +103,73 @@ namespace Etch.OrchardCore.Favicon.Controllers
         {
             var settings = await GetSettings();
 
-            if (settings == null || !settings.HasFavicon)
+            if (settings == null || !settings.HasFallbackFavicon)
             {
                 return NotFound();
             }
 
-            _contentTypeProvider.TryGetContentType(settings.FaviconPath, out var contentType);
-            return File(await _mediaFileStore.GetFileStreamAsync(settings.FaviconPath), contentType ?? DefaultMimeTypes.Favicon);
+            _contentTypeProvider.TryGetContentType(settings.FallbackFaviconPath, out var contentType);
+            return File(await _mediaFileStore.GetFileStreamAsync(settings.FallbackFaviconPath), contentType ?? DefaultMimeTypes.Favicon);
+        }
+
+        [HttpGet]
+        [Route("favicon-32x32.png")]
+        public async Task<IActionResult> FaviconLarge()
+        {
+            var settings = await GetSettings();
+
+            if (settings == null || !settings.HasLargeFavicon)
+            {
+                return NotFound();
+            }
+
+            _contentTypeProvider.TryGetContentType(settings.LargeFaviconPath, out var contentType);
+            return File(await _mediaFileStore.GetFileStreamAsync(settings.LargeFaviconPath), contentType ?? DefaultMimeTypes.PngIcon);
+        }
+
+        [HttpGet]
+        [Route("favicon-16x16.png")]
+        public async Task<IActionResult> FaviconDefault()
+        {
+            var settings = await GetSettings();
+
+            if (settings == null || !settings.HasDefaultFavicon)
+            {
+                return NotFound();
+            }
+
+            _contentTypeProvider.TryGetContentType(settings.DefaultFaviconPath, out var contentType);
+            return File(await _mediaFileStore.GetFileStreamAsync(settings.DefaultFaviconPath), contentType ?? DefaultMimeTypes.PngIcon);
+        }
+
+        [HttpGet]
+        [Route("icon.png")]
+        public async Task<IActionResult> Icon()
+        {
+            var settings = await GetSettings();
+
+            if (settings == null || !settings.HasAppleTouchIcon)
+            {
+                return NotFound();
+            }
+
+            _contentTypeProvider.TryGetContentType(settings.AppleTouchIconPath, out var contentType);
+            return File(await _mediaFileStore.GetFileStreamAsync(settings.AppleTouchIconPath), contentType ?? DefaultMimeTypes.PngIcon);
+        }
+
+        [HttpGet]
+        [Route("safari-pinned-tab.svg")]
+        public async Task<IActionResult> SafariPinnedTab()
+        {
+            var settings = await GetSettings();
+
+            if (settings == null || !settings.HasSafariPinnedTab)
+            {
+                return NotFound();
+            }
+
+            _contentTypeProvider.TryGetContentType(settings.SafariPinnedTabPath, out var contentType);
+            return File(await _mediaFileStore.GetFileStreamAsync(settings.SafariPinnedTabPath), contentType ?? DefaultMimeTypes.SvgIcon);
         }
 
         [HttpGet]
@@ -95,21 +185,6 @@ namespace Etch.OrchardCore.Favicon.Controllers
 
             _contentTypeProvider.TryGetContentType(settings.TilePath, out var contentType);
             return File(await _mediaFileStore.GetFileStreamAsync(settings.TilePath), contentType ?? DefaultMimeTypes.Tile);
-        }
-
-        [HttpGet]
-        [Route("tile-wide.png")]
-        public async Task<IActionResult> TileWide()
-        {
-            var settings = await GetSettings();
-
-            if (settings == null || !settings.HasTileWide)
-            {
-                return NotFound();
-            }
-
-            _contentTypeProvider.TryGetContentType(settings.TileWidePath, out var contentType);
-            return File(await _mediaFileStore.GetFileStreamAsync(settings.TileWidePath), contentType ?? DefaultMimeTypes.Tile);
         }
 
         [HttpGet]

--- a/DefaultMimeTypes.cs
+++ b/DefaultMimeTypes.cs
@@ -2,9 +2,10 @@
 {
     public static class DefaultMimeTypes
     {
-        public const string AppleTouchIcon = "image/png";
         public const string BrowserConfig = "application/xml";
         public const string Favicon = "image/x-icon";
+        public const string PngIcon = "image/png";
+        public const string SvgIcon = "image/svg+xml";
         public const string Tile = "image/png";
         public const string WebAppManifest = "application/manifest+json";
     }

--- a/Filters/FaviconFilter.cs
+++ b/Filters/FaviconFilter.cs
@@ -53,17 +53,37 @@ namespace Etch.OrchardCore.Favicon.Filters
 
                 if (faviconSettings != null && faviconSettings.HasAppleTouchIcon)
                 {
-                    _resourceManager.RegisterLink(new LinkEntry { Href = $"{pathBase}/icon.png", Rel = "apple-touch-icon" });
+                    _resourceManager.RegisterLink(CreateLinkEntry(context, "apple-touch-icon.png", "apple-touch-icon", "180x180"));
                 }
 
-                if (faviconSettings != null && faviconSettings.HasFavicon)
+                if (faviconSettings != null && faviconSettings.HasDefaultFavicon)
                 {
-                    _resourceManager.RegisterLink(new LinkEntry { Href = $"{pathBase}/favicon.ico", Rel = "shortcut icon" });
+                    _resourceManager.RegisterLink(CreateLinkEntry(context, "favicon-16x16.png", "icon", "16x16", "image/png"));
+                }
+
+                if (faviconSettings != null && faviconSettings.HasLargeFavicon)
+                {
+                    _resourceManager.RegisterLink(CreateLinkEntry(context, "favicon-32x32.png", "icon", "32x32", "image/png"));
                 }
 
                 if (faviconSettings != null && faviconSettings.HasWebAppManifest)
                 {
                     _resourceManager.RegisterLink(new LinkEntry { Href = $"{pathBase}/site.webmanifest", Rel = "manifest" });
+                }
+
+                if (faviconSettings != null && faviconSettings.HasSafariPinnedTab)
+                {
+                    _resourceManager.RegisterLink(CreateLinkEntry(context, "safari-pinned-tab.svg", "mask-icon", null, null, faviconSettings.SafariPinnedTabColourValue));
+                }
+
+                if (faviconSettings != null && faviconSettings.HasTileColour)
+                {
+                    _resourceManager.AppendMeta(new MetaEntry { Name = "msapplication-TileColor", Content = faviconSettings.TileColourValue }, ",");
+                }
+
+                if (faviconSettings != null && faviconSettings.HasThemeColour)
+                {
+                    _resourceManager.AppendMeta(new MetaEntry { Name = "theme-color", Content = faviconSettings.ThemeColourValue }, ",");
                 }
             } 
             catch (Exception ex)
@@ -72,6 +92,32 @@ namespace Etch.OrchardCore.Favicon.Filters
             }
 
             await next.Invoke();
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private LinkEntry CreateLinkEntry(ResultExecutingContext context, string href, string rel, string sizes = null, string type = null, string colour = null)
+        {
+            var entry = new LinkEntry { Href = $"{context.HttpContext.Request.PathBase}/{href}", Rel = rel };
+
+            if (!string.IsNullOrWhiteSpace(type))
+            {
+                entry.Type = type;
+            }
+
+            if (!string.IsNullOrWhiteSpace(sizes))
+            {
+                entry.AddAttribute("sizes", sizes);
+            }
+
+            if (!string.IsNullOrWhiteSpace(colour))
+            {
+                entry.AddAttribute("color", colour);
+            }
+
+            return entry;
         }
 
         #endregion

--- a/Migrations.cs
+++ b/Migrations.cs
@@ -30,6 +30,13 @@ namespace Etch.OrchardCore.Favicon
             return 1;
         }
 
+        public async Task<int> UpdateFrom1Async()
+        {
+            await _recipeMigrator.ExecuteAsync("1.recipe.json", this);
+
+            return 2;
+        }
+
         #endregion
     }
 }

--- a/Migrations/1.recipe.json
+++ b/Migrations/1.recipe.json
@@ -1,0 +1,229 @@
+{
+  "steps": [
+    {
+      "name": "ContentDefinition",
+      "ContentTypes": [
+        {
+          "Name": "FaviconSettings",
+          "DisplayName": "Favicon",
+          "Settings": {
+            "ContentTypeSettings": {
+              "Stereotype": "CustomSettings"
+            },
+            "FullTextAspectSettings": {}
+          },
+          "ContentTypePartDefinitionRecords": [
+            {
+              "PartName": "FaviconSettings",
+              "Name": "FaviconSettings",
+              "Settings": {
+                "ContentTypePartSettings": {
+                  "Position": "0"
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "ContentParts": [
+        {
+          "Name": "FaviconSettings",
+          "Settings": {},
+          "ContentPartFieldDefinitionRecords": [
+            {
+              "FieldName": "MediaField",
+              "Name": "Favicon",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Default Favicon",
+                  "Position": "1"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Icon should be a .png with dimensions of 16x16.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "AppleTouchIcon",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Apple Touch Icon",
+                  "Position": "3"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Icon should be a .png with dimensions of 180x180.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "Tile",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Tile",
+                  "Position": "7"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Tile should be a .png with dimensions of 150x150.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "BrowserConfig",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Browser Config",
+                  "Position": "8"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Config file is used to customize the tile displayed when users pin your site to the Windows 8.1 start screen. In there you can define custom tile colors, custom images or even live tiles.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "WebAppManifest",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Web App Manifest",
+                  "Position": "9"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Provides information about a web application in a JSON text file.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "FaviconFallback",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Favicon Fallback",
+                  "Position": "0"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Icon should be a .ico with dimensions of 32x32.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "LargeFavicon",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Large Favicon",
+                  "Position": "2"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Icon should be a .png with dimensions of 32x32.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "AndroidSmallIcon",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Android Small Icon",
+                  "Position": "5"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Icon should be a .png with dimensions of 192x192.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "AndroidLargeIcon",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Android Large Icon",
+                  "Position": "6"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Icon should be a .png with dimensions of 512x512.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "MediaField",
+              "Name": "SafariPinnedTab",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Safari Pinned Tab",
+                  "Position": "10"
+                },
+                "MediaFieldSettings": {
+                  "Hint": "Icon that the user sees when they pin your site within Safari.",
+                  "Multiple": false
+                },
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "SafariPinnedTabColour",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Safari Pinned Tab Colour",
+                  "Editor": "Color",
+                  "Position": "11"
+                },
+                "TextFieldSettings": {},
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "TileColour",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Tile Colour",
+                  "Editor": "Color",
+                  "Position": "8"
+                },
+                "TextFieldSettings": {},
+                "ContentIndexSettings": {}
+              }
+            },
+            {
+              "FieldName": "TextField",
+              "Name": "ThemeColour",
+              "Settings": {
+                "ContentPartFieldSettings": {
+                  "DisplayName": "Theme Colour",
+                  "Editor": "Color",
+                  "Position": "12"
+                },
+                "TextFieldSettings": {
+                  "Hint": "Set the toolbar colour."
+                },
+                "ContentIndexSettings": {}
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/Migrations/create.recipe.json
+++ b/Migrations/create.recipe.json
@@ -78,22 +78,6 @@
             },
             {
               "FieldName": "MediaField",
-              "Name": "TileWide",
-              "DisplayName": "Tile Wide",
-              "Settings": {
-                "ContentPartFieldSettings": {
-                  "DisplayName": "TileWide",
-                  "Position": "3"
-                },
-                "MediaFieldSettings": {
-                  "Hint": "Tile should be a .png with dimensions of 558x270.",
-                  "Multiple": false
-                },
-                "ContentIndexSettings": {}
-              }
-            },
-            {
-              "FieldName": "MediaField",
               "Name": "BrowserConfig",
               "Settings": {
                 "ContentPartFieldSettings": {

--- a/Models/FaviconSettings.cs
+++ b/Models/FaviconSettings.cs
@@ -6,6 +6,36 @@ namespace Etch.OrchardCore.Favicon.Models
 {
     public class FaviconSettings : ContentPart
     {
+        #region Android Icon
+
+        public string AndroidLargeIconPath
+        {
+            get
+            {
+                return this.Get<MediaField>("AndroidLargeIcon")?.Paths?.FirstOrDefault() ?? null;
+            }
+        }
+
+        public string AndroidSmallIconPath
+        {
+            get
+            {
+                return this.Get<MediaField>("AndroidSmallIcon")?.Paths?.FirstOrDefault() ?? null;
+            }
+        }
+
+        public bool HasAndroidLargeIcon
+        {
+            get { return this.Get<MediaField>("AndroidLargeIcon")?.Paths?.Any() ?? false; }
+        }
+
+        public bool HasAndroidSmallIcon
+        {
+            get { return this.Get<MediaField>("AndroidSmallIcon")?.Paths?.Any() ?? false; }
+        }
+
+        #endregion
+
         #region Apple Touch Icon
 
         public string AppleTouchIconPath
@@ -42,7 +72,7 @@ namespace Etch.OrchardCore.Favicon.Models
 
         #region Favicon
 
-        public string FaviconPath
+        public string DefaultFaviconPath
         {
             get
             {
@@ -50,14 +80,97 @@ namespace Etch.OrchardCore.Favicon.Models
             }
         }
 
-        public bool HasFavicon
+        public string FallbackFaviconPath
+        {
+            get
+            {
+                return this.Get<MediaField>("FallbackFavicon")?.Paths?.FirstOrDefault() ?? null;
+            }
+        }
+
+        public bool HasDefaultFavicon
         {
             get { return this.Get<MediaField>("Favicon")?.Paths?.Any() ?? false; }
+        }
+
+        public bool HasFallbackFavicon
+        {
+            get { return this.Get<MediaField>("FallbackFavicon")?.Paths?.Any() ?? false; }
+        }
+
+        public bool HasLargeFavicon
+        {
+            get { return this.Get<MediaField>("LargeFavicon")?.Paths?.Any() ?? false; }
+        }
+
+        public string LargeFaviconPath
+        {
+            get
+            {
+                return this.Get<MediaField>("LargeFavicon")?.Paths?.FirstOrDefault() ?? null;
+            }
+        }
+
+        #endregion
+
+        #region SafariPinnedTab
+
+        public bool HasSafariPinnedTab
+        {
+            get { return this.Get<MediaField>("SafariPinnedTab")?.Paths?.Any() ?? false; }
+        }
+
+        public bool HasSafariPinnedTabColour
+        {
+            get { return !string.IsNullOrWhiteSpace(this.Get<TextField>("SafariPinnedTabColour")?.Text); }
+        }
+
+        public string SafariPinnedTabColourValue
+        {
+            get
+            {
+                return this.Get<TextField>("SafariPinnedTabColour")?.Text ?? null;
+            }
+        }
+
+        public string SafariPinnedTabPath
+        {
+            get
+            {
+                return this.Get<MediaField>("SafariPinnedTab")?.Paths?.FirstOrDefault() ?? null;
+            }
+        }
+
+        #endregion
+
+        #region Theme
+
+        public bool HasThemeColour
+        {
+            get { return !string.IsNullOrWhiteSpace(this.Get<TextField>("ThemeColour")?.Text); }
+        }
+
+        public string ThemeColourValue
+        {
+            get
+            {
+                return this.Get<TextField>("ThemeColour")?.Text ?? null;
+            }
         }
 
         #endregion
 
         #region Tile
+
+        public bool HasTile
+        {
+            get { return this.Get<MediaField>("Tile")?.Paths?.Any() ?? false; }
+        }
+
+        public bool HasTileColour
+        {
+            get { return !string.IsNullOrWhiteSpace(this.Get<TextField>("TileColour")?.Text); }
+        }
 
         public string TilePath
         {
@@ -67,26 +180,12 @@ namespace Etch.OrchardCore.Favicon.Models
             }
         }
 
-        public bool HasTile
-        {
-            get { return this.Get<MediaField>("Tile")?.Paths?.Any() ?? false; }
-        }
-
-        #endregion
-
-        #region Tile Wide
-
-        public string TileWidePath
+        public string TileColourValue
         {
             get
             {
-                return this.Get<MediaField>("TileWide")?.Paths?.FirstOrDefault() ?? null;
+                return this.Get<TextField>("TileColour")?.Text ?? null;
             }
-        }
-
-        public bool HasTileWide
-        {
-            get { return this.Get<MediaField>("TileWide")?.Paths?.Any() ?? false; }
         }
 
         #endregion

--- a/Models/FaviconSettings.cs
+++ b/Models/FaviconSettings.cs
@@ -1,5 +1,6 @@
 ﻿using OrchardCore.ContentManagement;
 using OrchardCore.Media.Fields;
+using OrchardCore.ContentFields.Fields;
 using System.Linq;
 
 namespace Etch.OrchardCore.Favicon.Models


### PR DESCRIPTION
- Add new fallback & large favicon fields
- Add fields for small & large Android icons
- Remove tile wide field (any existing sites will need to delete this
manually from the definitions)
- Add safari pinned tab icon & colour fields
- Add theme colour field
- Add tile colour field
- Update markup to output the following:

```
<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
<link rel="manifest" href="/site.webmanifest">
<link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
<meta name="msapplication-TileColor" content="#da532c">
<meta name="theme-color" content="#ffffff">
```

- Update routes to serve all images defined on available fields

Resolves #1.